### PR TITLE
use jdk21 for CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           - jvm: 21
-            platform: ubuntu-23.04
+            platform: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - jvm: 17
-            platform: ubuntu-22.04
+          - jvm: 21
+            platform: ubuntu-23.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
As we're anyway on JDK20 min due to vector api usage.