### PR TITLE
add progress indicator on HF downloads

### DIFF
--- a/src/main/scala/ai/nixiesearch/core/PrintProgress.scala
+++ b/src/main/scala/ai/nixiesearch/core/PrintProgress.scala
@@ -2,6 +2,7 @@ package ai.nixiesearch.core
 
 import cats.effect.IO
 import fs2.Pipe
+import org.apache.commons.io.FileUtils
 
 object PrintProgress extends Logging {
   case class ProgressPeriod(
@@ -12,6 +13,26 @@ object PrintProgress extends Logging {
     def inc(events: Int) =
       copy(total = total + events, batchTotal = batchTotal + events)
   }
+
+  def bytes[T]: Pipe[IO, T, T] = input =>
+    input.scanChunks(ProgressPeriod()) { case (pp @ ProgressPeriod(start, total, batch), next) =>
+      val now = System.currentTimeMillis()
+      if ((now - start > 1000)) {
+        val timeDiffSeconds = (now - start) / 1000.0
+        val perf            = math.round(batch / timeDiffSeconds)
+        val totalHuman      = FileUtils.byteCountToDisplaySize(total)
+        val perfHuman       = FileUtils.byteCountToDisplaySize(perf)
+        logger.info(
+          s"processed $totalHuman, rate: ${perfHuman}/s"
+        )
+        (
+          pp.copy(start = now, batchTotal = 0).inc(next.size),
+          next
+        )
+      } else {
+        (pp.inc(next.size), next)
+      }
+    }
 
   def tap[T](suffix: String): Pipe[IO, T, T] = input =>
     input.scanChunks(ProgressPeriod()) { case (pp @ ProgressPeriod(start, total, batch), next) =>

--- a/src/main/scala/ai/nixiesearch/core/nn/model/HuggingFaceClient.scala
+++ b/src/main/scala/ai/nixiesearch/core/nn/model/HuggingFaceClient.scala
@@ -1,6 +1,6 @@
 package ai.nixiesearch.core.nn.model
 
-import ai.nixiesearch.core.Logging
+import ai.nixiesearch.core.{Logging, PrintProgress}
 import ai.nixiesearch.core.nn.ModelHandle.HuggingFaceHandle
 import ai.nixiesearch.core.nn.model.HuggingFaceClient.ModelResponse
 import ai.nixiesearch.core.nn.model.HuggingFaceClient.ModelResponse.Sibling
@@ -41,7 +41,9 @@ case class HuggingFaceClient(client: Client[IO], endpoint: Uri, cache: ModelFile
       .evalMap(response =>
         response.status.code match {
           case 200 =>
-            info("HuggingFace API: HTTP 200") *> response.entity.body.compile
+            info("HuggingFace API: HTTP 200") *> response.entity.body
+              .through(PrintProgress.bytes)
+              .compile
               .foldChunks(new ByteArrayOutputStream())((acc, c) => {
                 acc.writeBytes(c.toArray)
                 acc


### PR DESCRIPTION
Now it looks like this:
```
13:52:23.724 INFO  ai.nixiesearch.core.PrintProgress$ - processed 52 MB, rate: 6 MB/s
13:52:24.726 INFO  ai.nixiesearch.core.PrintProgress$ - processed 58 MB, rate: 6 MB/s
[13.443s][info][gc] GC(11) Pause Young (Normal) (G1 Evacuation Pause) 390M->82M(526M) 4.202ms
13:52:25.727 INFO  ai.nixiesearch.core.PrintProgress$ - processed 65 MB, rate: 6 MB/s
13:52:26.729 INFO  ai.nixiesearch.core.PrintProgress$ - processed 71 MB, rate: 6 MB/s
13:52:27.730 INFO  ai.nixiesearch.core.PrintProgress$ - processed 78 MB, rate: 6 MB/s
13:52:28.731 INFO  ai.nixiesearch.core.PrintProgress$ - processed 84 MB, rate: 6 MB/s
[17.352s][info][gc] GC(12) Pause Young (Normal) (G1 Evacuation Pause) 519M->146M(528M) 4.010ms
13:52:29.732 INFO  ai.nixiesearch.core.PrintProgress$ - processed 91 MB, rate: 6 MB/s
13:52:30.751 INFO  ai.nixiesearch.core.PrintProgress$ - processed 97 MB, rate: 6 MB/s
13:52:31.752 INFO  ai.nixiesearch.core.PrintProgress$ - processed 103 MB, rate: 5 MB/s
13:52:32.754 INFO  ai.nixiesearch.core.PrintProgress$ - processed 109 MB, rate: 6 MB/s
```