### PR TITLE
allow null field values

### DIFF
--- a/src/main/scala/ai/nixiesearch/core/Document.scala
+++ b/src/main/scala/ai/nixiesearch/core/Document.scala
@@ -5,6 +5,7 @@ import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json, JsonObject}
 import cats.implicits.*
 
 import java.util.UUID
+import scala.annotation.tailrec
 
 case class Document(fields: List[Field])
 
@@ -28,45 +29,57 @@ object Document {
         c.value.asObject match {
           case None => Left(DecodingFailure(s"document should be a JSON object: ${c.value}", c.history))
           case Some(obj) =>
-            val fields = obj.toMap
-            val decoded = fields.toList.traverse {
-              case ("_id", json) =>
-                json.fold[Either[DecodingFailure, Field]](
-                  jsonNull = Right(TextField("_id", UUID.randomUUID().toString)),
-                  jsonBoolean = bool =>
-                    Left(DecodingFailure(s"_id field can be either a number or a string, got $bool", c.history)),
-                  jsonNumber = num =>
-                    num.toLong match {
-                      case Some(long) => Right(TextField("_id", num.toString))
-                      case None =>
-                        Left(
-                          DecodingFailure(
-                            s"_id field cannot be a real number, but string|long|uuid, got $num",
-                            c.history
-                          )
-                        )
-                    },
-                  jsonString = str => Right(TextField("_id", str)),
-                  jsonArray = arr => Left(DecodingFailure(s"_id field cannot be an array, got $arr", c.history)),
-                  jsonObject = obj => Left(DecodingFailure(s"_id field cannot be an object, got $obj", c.history))
-                )
-              case (key, json) => decodeField(c, key, json)
-            }
-            decoded.map(fields => Document(fields))
+            decodeObject(c, obj.toList).map(fields => Document(fields.reverse))
         }
       )
       .ensure(_.fields.nonEmpty, "document cannot contain zero fields")
 
-  def decodeField(c: HCursor, name: String, json: Json): Decoder.Result[Field] = json.fold(
-    jsonNull = Left(DecodingFailure("cannot parse null field", c.history)),
+  @tailrec
+  def decodeObject(c: HCursor, next: List[(String, Json)], acc: List[Field] = Nil): Decoder.Result[List[Field]] =
+    next match {
+      case Nil => Right(acc)
+      case ("_id", json) :: tail =>
+        decodeId(c, json) match {
+          case Left(error) => Left(error)
+          case Right(id)   => decodeObject(c, tail, id +: acc)
+        }
+      case (name, json) :: tail =>
+        decodeField(c, name, json) match {
+          case Left(error)        => Left(error)
+          case Right(None)        => decodeObject(c, tail, acc)
+          case Right(Some(field)) => decodeObject(c, tail, field +: acc)
+        }
+    }
+
+  def decodeId(c: HCursor, json: Json): Decoder.Result[Field] = json.fold[Either[DecodingFailure, Field]](
+    jsonNull = Right(TextField("_id", UUID.randomUUID().toString)),
+    jsonBoolean = bool => Left(DecodingFailure(s"_id field can be either a number or a string, got $bool", c.history)),
+    jsonNumber = num =>
+      num.toLong match {
+        case Some(long) => Right(TextField("_id", num.toString))
+        case None =>
+          Left(
+            DecodingFailure(
+              s"_id field cannot be a real number, but string|long|uuid, got $num",
+              c.history
+            )
+          )
+      },
+    jsonString = str => Right(TextField("_id", str)),
+    jsonArray = arr => Left(DecodingFailure(s"_id field cannot be an array, got $arr", c.history)),
+    jsonObject = obj => Left(DecodingFailure(s"_id field cannot be an object, got $obj", c.history))
+  )
+
+  def decodeField(c: HCursor, name: String, json: Json): Decoder.Result[Option[Field]] = json.fold(
+    jsonNull = Right(None),
     jsonBoolean = _ => Left(DecodingFailure("cannot parse null field", c.history)),
     jsonNumber = n =>
       n.toInt match {
-        case Some(int) => Right(IntField(name, int))
-        case None      => Right(FloatField(name, n.toFloat))
+        case Some(int) => Right(Some(IntField(name, int)))
+        case None      => Right(Some(FloatField(name, n.toFloat)))
 
       },
-    jsonString = s => Right(TextField(name, s)),
+    jsonString = s => Right(Some(TextField(name, s))),
     jsonArray = _ => Left(DecodingFailure("cannot parse array field", c.history)),
     jsonObject = _ => Left(DecodingFailure("cannot parse object field", c.history))
   )

--- a/src/test/scala/ai/nixiesearch/core/DocumentJsonTest.scala
+++ b/src/test/scala/ai/nixiesearch/core/DocumentJsonTest.scala
@@ -14,6 +14,13 @@ class DocumentJsonTest extends AnyFlatSpec with Matchers {
     )
   }
 
+  it should "accept null values" in {
+    val json = """{"_id": "a", "title": null, "count": 1}"""
+    decode[Document](json) shouldBe Right(
+      Document(List(TextField("_id", "a"), IntField("count", 1)))
+    )
+  }
+
   it should "fail on zero fields" in {
     decode[Document]("{}") shouldBe a[Left[_, _]]
   }


### PR DESCRIPTION
So it will accept docs like `{"_id": 1, "field": null}`. The behavior is to ignore these fields.