### PR TITLE
bump http4s to 1.0-M40

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -1,7 +1,7 @@
 import sbt.*
 
 object Deps {
-  lazy val http4sVersion    = "1.0.0-M38"
+  lazy val http4sVersion    = "1.0.0-M40"
   lazy val scalatestVersion = "3.2.17"
   lazy val circeVersion     = "0.14.6"
   lazy val circeYamlVersion = "0.14.2"

--- a/src/main/scala/ai/nixiesearch/core/Logging.scala
+++ b/src/main/scala/ai/nixiesearch/core/Logging.scala
@@ -2,9 +2,12 @@ package ai.nixiesearch.core
 
 import cats.effect.IO
 import org.slf4j.LoggerFactory
+import org.typelevel.log4cats.slf4j.Slf4jFactory
 
 trait Logging {
   protected val logger = LoggerFactory.getLogger(getClass)
+
+  given loggerFactory: org.typelevel.log4cats.LoggerFactory[IO] = Slf4jFactory.create[IO]
 
   def debug(msg: String): IO[Unit]                = IO(logger.debug(msg))
   def info(msg: String): IO[Unit]                 = IO(logger.info(msg))

--- a/src/main/scala/ai/nixiesearch/core/nn/model/HuggingFaceClient.scala
+++ b/src/main/scala/ai/nixiesearch/core/nn/model/HuggingFaceClient.scala
@@ -79,7 +79,7 @@ case class HuggingFaceClient(client: Client[IO], endpoint: Uri, cache: ModelFile
   }
 }
 
-object HuggingFaceClient {
+object HuggingFaceClient extends Logging {
   val HUGGINGFACE_API_ENDPOINT = "https://huggingface.co"
 
   case class ModelResponse(id: String, siblings: List[Sibling])


### PR DESCRIPTION
As we now not using unsupported blaze, and scala-steward now should correctly bump the version.