### PR TITLE
Fix race in HF model loader

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,8 @@ scalacOptions ++= Seq(
   "-no-indent"
 )
 
+concurrentRestrictions in Global := Seq(Tags.limitAll(1))
+
 Compile / mainClass := Some("ai.nixiesearch.main.Main")
 
 Compile / discoveredMainClasses := Seq()

--- a/src/main/scala/ai/nixiesearch/core/nn/model/BiEncoderCache.scala
+++ b/src/main/scala/ai/nixiesearch/core/nn/model/BiEncoderCache.scala
@@ -8,13 +8,14 @@ import ai.nixiesearch.core.Logging
 import ai.nixiesearch.core.nn.ModelHandle
 import cats.effect.IO
 import cats.effect.kernel.Resource
-import cats.effect.std.{MapRef, Queue}
+import cats.effect.std.{MapRef, Queue, Semaphore}
 import cats.implicits.*
 
 case class BiEncoderCache(
     encoders: MapRef[IO, ModelHandle, Option[OnnxBiEncoder]],
     shutdownQueue: Queue[IO, IO[Unit]],
-    cacheConfig: EmbeddingCacheConfig
+    cacheConfig: EmbeddingCacheConfig,
+    lock: Semaphore[IO]
 ) extends Logging {
   def get(handle: ModelHandle): IO[OnnxBiEncoder] = {
     val ref = encoders(handle)
@@ -23,10 +24,12 @@ case class BiEncoderCache(
       case None =>
         for {
           _       <- info(s"Loading ONNX models: $handle")
+          _       <- lock.acquire *> debug("acquired lock for model loading")
           session <- OnnxSession.load(handle)
           enc = OnnxBiEncoder(session, cacheConfig)
           _ <- ref.set(Some(enc))
           _ <- shutdownQueue.offer(IO(enc.close()))
+          _ <- lock.release *> debug("released lock for model loading")
         } yield {
           enc
         }
@@ -43,9 +46,10 @@ object BiEncoderCache extends Logging {
   def create(cacheConfig: EmbeddingCacheConfig): Resource[IO, BiEncoderCache] = {
     Resource.make(for {
       queue <- Queue.bounded[IO, IO[Unit]](1024)
+      lock  <- Semaphore[IO](1)
       cache <- MapRef.ofConcurrentHashMap[IO, ModelHandle, OnnxBiEncoder]()
     } yield {
-      BiEncoderCache(cache, queue, cacheConfig)
+      BiEncoderCache(cache, queue, cacheConfig, lock)
     })(_.close())
 
   }


### PR DESCRIPTION
So when you load the same model twice at the same time, it breaks. Maybe we should later allow concurrency here, but not now.