### PR TITLE
stop AWS dep upgrades for 30 days

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,4 @@
+dependencyOverrides = [{
+  pullRequests = { frequency = "30 days" },
+  dependency = { groupId = "software.amazon.awssdk" }
+}]


### PR DESCRIPTION
Otherwise scala steward does a PR every day