### PR TITLE
avoid loading same onnx model twice

### DIFF
--- a/src/main/scala/ai/nixiesearch/config/mapping/IndexMapping.scala
+++ b/src/main/scala/ai/nixiesearch/config/mapping/IndexMapping.scala
@@ -76,7 +76,7 @@ case class IndexMapping(
   def modelHandles(): List[ModelHandle] =
     fields.values.toList.collect { case TextLikeFieldSchema(_, SemanticSearchLikeType(model, _), _, _, _, _, _, _) =>
       model
-    }
+    }.distinct
 
   def suggestFields(): List[String] =
     fields.values.toList.collect { case TextLikeFieldSchema(name, _, _, _, _, _, _, Some(_)) =>

--- a/src/test/scala/ai/nixiesearch/config/mapping/IndexMappingTest.scala
+++ b/src/test/scala/ai/nixiesearch/config/mapping/IndexMappingTest.scala
@@ -52,6 +52,18 @@ class IndexMappingTest extends AnyFlatSpec with Matchers {
     decoded shouldBe Right(mapping)
   }
 
+  it should "deduplicate same model handles" in {
+    val mapping = IndexMapping(
+      name = IndexName("foo"),
+      fields = Map(
+        "text1" -> TextFieldSchema("text1", search = SemanticSearch()),
+        "text2" -> TextFieldSchema("text2", search = SemanticSearch()),
+        "text3" -> TextFieldSchema("text3", search = SemanticSearch())
+      )
+    )
+    mapping.modelHandles().size shouldBe 1
+  }
+
   "yaml decoder" should "add an implicit id field mapping" in {
     val yaml =
       """


### PR DESCRIPTION
What if you have multiple text fields with the same embedding model? You don't need N ONNX model instances.