### PR TITLE
use mmap for onnx model loading

### DIFF
--- a/deploy/nixiesearch.sh
+++ b/deploy/nixiesearch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -euxo pipefail
-OPTS=${JAVA_OPTS:-"-Xmx1g -verbose:gc --add-modules jdk.incubator.vector"}
+OPTS=${JAVA_OPTS:-"-Xmx2g -verbose:gc --add-modules jdk.incubator.vector"}
 
 exec /usr/bin/java $OPTS --enable-preview -jar /app/nixiesearch.jar "$@"
 

--- a/src/main/scala/ai/nixiesearch/core/nn/model/embedding/EmbedModelDict.scala
+++ b/src/main/scala/ai/nixiesearch/core/nn/model/embedding/EmbedModelDict.scala
@@ -93,8 +93,8 @@ object EmbedModelDict extends Logging {
       (modelPath, vocabPath, config)
     })
     onnxEmbedder <- OnnxEmbedModel.create(
-      model = new FileInputStream(model.toFile),
-      dic = new FileInputStream(vocab.toFile),
+      model = model,
+      dic = vocab,
       dim = config.hidden_size,
       prompt = conf.prompt,
       seqlen = conf.maxTokens
@@ -117,8 +117,8 @@ object EmbedModelDict extends Logging {
         (path.toNioPath.resolve(modelFile), path.toNioPath.resolve(tokenizerFile), config)
       })
       onnxEmbedder <- OnnxEmbedModel.create(
-        model = new FileInputStream(model.toFile),
-        dic = new FileInputStream(vocab.toFile),
+        model = model,
+        dic = vocab,
         dim = config.hidden_size,
         prompt = conf.prompt,
         seqlen = conf.maxTokens


### PR DESCRIPTION
Should fix https://github.com/nixiesearch/nixiesearch/issues/363

As we're now not loading the model itself in jvm heap, and just mmapping it directly into the onnx runtime.