### PR TITLE
use cuda 12.4 in the docker image to fix compat issue with nvidia-550 host drivers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -96,7 +96,7 @@ docker / dockerfile := {
   val artifactTargetPath = s"/app/${artifact.name}"
 
   new Dockerfile {
-    from(s"--platform=$PLATFORM ubuntu:noble-20240605")
+    from(s"--platform=$PLATFORM ubuntu:jammy-20240911.1")
     runRaw(
       List(
         "apt-get update",
@@ -108,12 +108,12 @@ docker / dockerfile := {
     if (GPU) {
       runRaw(
         List(
-          "wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb",
+          "wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb",
           "dpkg -i cuda-keyring_1.1-1_all.deb",
           "apt-get update",
-          "apt-get install -y --no-install-recommends cuda-toolkit-12-6 nvidia-headless-560-open cudnn9-cuda-12-6",
+          "apt-get install -y --no-install-recommends cuda-toolkit-12-4 nvidia-headless-550-open cudnn9-cuda-12",
           "rm -rf /usr/lib/x86_64-linux-gnu/lib*static_v9.a",
-          "rm -rf /usr/local/cuda-12.6/targets/x86_64-linux/lib/lib*.a",
+          "rm -rf /usr/local/cuda-12.4/targets/x86_64-linux/lib/lib*.a",
           "rm -rf /opt/nvidia"
         ).mkString(" && ")
       )


### PR DESCRIPTION
As otherwise you might get CUDA forward-compat error when running 12.6 docker over the 12.4 host.