### PR TITLE
add bulk delete api

### DIFF
--- a/docs/docs/reference/api/index.md
+++ b/docs/docs/reference/api/index.md
@@ -66,12 +66,47 @@ Response:
 Example:
 
 ```shell
-$ curl -XPOST -d '{"segments": 1}' http://localhost:8080/msmarco/_merge|jq .
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-100    24  100    24    0     0   3625      0 --:--:-- --:--:-- --:--:--  4000
+curl -XPOST -d '{"segments": 1}' http://localhost:8080/msmarco/_merge|jq .
+```
+```
 {
   "status": "ok",
-  "tool": 3
+  "took": 3
+}
+```
+
+### Deletes
+
+#### Delete by docid
+
+todo
+
+#### Delete by query
+
+Route: `POST /<index_name>/_delete`
+
+Payload:
+
+```json
+{
+  "filters": {
+    "include": "...",
+    "exclude": "..."
+  }
+}
+```
+
+* `filters`: optional, Filters. Has the same JSON format as [filters](../../features/search/filter.md). 
+
+Example, deleting all documents from the index:
+
+```shell
+curl -XPOST -d '{}' http://localhost:8080/msmarco/_delete|jq .
+```
+```
+{
+  "status": "ok",
+  "took": 3,
+  "deleted": 100
 }
 ```

--- a/src/test/scala/ai/nixiesearch/api/query/UpdateDeleteTest.scala
+++ b/src/test/scala/ai/nixiesearch/api/query/UpdateDeleteTest.scala
@@ -1,5 +1,6 @@
 package ai.nixiesearch.api.query
 
+import ai.nixiesearch.api.filter.Filters
 import ai.nixiesearch.core.Document
 import ai.nixiesearch.core.field.*
 import ai.nixiesearch.util.{SearchTest, TestIndexMapping}
@@ -13,7 +14,7 @@ class UpdateDeleteTest extends SearchTest with Matchers {
     Document(List(TextField("_id", "2"), TextField("title", "white dress"))),
     Document(List(TextField("_id", "3"), TextField("title", "red pajama")))
   )
-  it should "delete documents" in withIndex { index =>
+  it should "delete documents by id" in withIndex { index =>
     {
       index.search(MatchQuery("title", "pajama")) shouldBe List("3")
       index.indexer.delete("3").unsafeRunSync()
@@ -21,6 +22,18 @@ class UpdateDeleteTest extends SearchTest with Matchers {
       index.indexer.index.sync().unsafeRunSync()
       index.searcher.sync().unsafeRunSync()
       index.search(MatchQuery("title", "pajama")) shouldBe List()
+    }
+  }
+
+  it should "delete documents by query" in withIndex { index =>
+    {
+      index.search(MatchQuery("title", "pajama")) shouldBe List("3")
+      val response = index.indexer.delete(None).unsafeRunSync()
+      index.indexer.flush().unsafeRunSync()
+      index.indexer.index.sync().unsafeRunSync()
+      index.searcher.sync().unsafeRunSync()
+      index.search(MatchAllQuery()) shouldBe List()
+      response shouldBe 3
     }
   }
 


### PR DESCRIPTION
Example, deleting all documents from the index:

```shell
curl -XPOST -d '{}' http://localhost:8080/msmarco/_delete|jq .
```
```
{
  "status": "ok",
  "took": 3,
  "deleted": 100
}
```