### PR TITLE
CI: skip API e2e test for external PRs

### DIFF
--- a/.github/workflows/e2e-embed-api.yml
+++ b/.github/workflows/e2e-embed-api.yml
@@ -43,4 +43,5 @@ jobs:
       env:
         COHERE_KEY: ${{ secrets.COHERE_KEY }}
         OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+      if: env.OPENAI_KEY != ''
       run: sbt -mem 5000 'testOnly --  -n e2e-api-embed'


### PR DESCRIPTION
Due to lack of proper way for sharing secrets 