### PR TITLE
Move all inference metrics from API endpoint to inner classes

### DIFF
--- a/src/main/scala/ai/nixiesearch/api/InferenceRoute.scala
+++ b/src/main/scala/ai/nixiesearch/api/InferenceRoute.scala
@@ -32,7 +32,7 @@ import org.http4s.headers.`Content-Type`
 
 import scala.util.{Failure, Success}
 
-class InferenceRoute(models: Models, metrics: Metrics) extends Route with Logging {
+class InferenceRoute(models: Models) extends Route with Logging {
 
   override val routes: HttpRoutes[IO] = HttpRoutes.of[IO] {
     case req @ POST -> Root / "inference" / "embedding" / modelName =>
@@ -111,13 +111,7 @@ class InferenceRoute(models: Models, metrics: Metrics) extends Route with Loggin
           CompletionFrame(token, took, false)
         }
         .through(StreamMark.pipe[CompletionFrame](tail = tok => tok.copy(last = true)))
-        .onFinalize(
-          IO(
-            metrics.inference.completionTimeSeconds
-              .labelValues(modelRef.name)
-              .inc((System.currentTimeMillis() - start) / 1000.0)
-          )
-        )
+
     } yield {
       next
     }

--- a/src/main/scala/ai/nixiesearch/api/InferenceRoute.scala
+++ b/src/main/scala/ai/nixiesearch/api/InferenceRoute.scala
@@ -74,8 +74,6 @@ class InferenceRoute(models: Models, metrics: Metrics) extends Route with Loggin
   }
 
   def embed(request: EmbeddingInferenceRequest, modelRef: ModelRef): IO[EmbeddingInferenceResponse] = for {
-    _     <- IO(metrics.inference.embedTotal.labelValues(modelRef.name).inc())
-    _     <- IO(metrics.inference.embedDocTotal.labelValues(modelRef.name).inc(request.input.size))
     start <- IO(System.currentTimeMillis())
     model <- IO.fromOption(models.embedding.embedders.get(modelRef))(UserError(s"model $modelRef not found"))
     docs <- IO(
@@ -91,7 +89,6 @@ class InferenceRoute(models: Models, metrics: Metrics) extends Route with Loggin
     )
     results <- models.embedding.encode(modelRef, TaskType.Raw, docs)
     finish  <- IO(System.currentTimeMillis())
-    _       <- IO(metrics.inference.embedTimeSeconds.labelValues(modelRef.name).inc((finish - start) / 1000.0))
   } yield {
     EmbeddingInferenceResponse(results.toList.map(embed => EmbeddingOutput(embed)), took = finish - start)
   }
@@ -107,14 +104,12 @@ class InferenceRoute(models: Models, metrics: Metrics) extends Route with Loggin
   def generateStreaming(request: CompletionRequest, modelRef: ModelRef): Stream[IO, CompletionFrame] = {
     for {
       start <- Stream.eval(IO(System.currentTimeMillis()))
-      _     <- Stream.eval(IO(metrics.inference.completionTotal.labelValues(modelRef.name).inc()))
       next <- models.generative
         .generate(modelRef, request.prompt, request.max_tokens)
         .through(DurationStream.pipe(System.currentTimeMillis()))
         .map { case (token, took) =>
           CompletionFrame(token, took, false)
         }
-        .evalTap(_ => IO(metrics.inference.completionGeneratedTokensTotal.labelValues(modelRef.name).inc()))
         .through(StreamMark.pipe[CompletionFrame](tail = tok => tok.copy(last = true)))
         .onFinalize(
           IO(

--- a/src/main/scala/ai/nixiesearch/core/metrics/InferenceMetrics.scala
+++ b/src/main/scala/ai/nixiesearch/core/metrics/InferenceMetrics.scala
@@ -45,4 +45,25 @@ case class InferenceMetrics(registry: PrometheusRegistry) {
     .help("Total embed query time in seconds")
     .labelNames("model")
     .register(registry)
+
+  val rankTotal = Counter
+    .builder()
+    .name("nixiesearch_inference_ranking_request_total")
+    .help("Total number of ranking queries")
+    .labelNames("model")
+    .register(registry)
+
+  val rankDocTotal = Counter
+    .builder()
+    .name("nixiesearch_inference_ranking_doc_total")
+    .help("Total number of ranked documents")
+    .labelNames("model")
+    .register(registry)
+
+  val rankTimeSeconds = Gauge
+    .builder()
+    .name("nixiesearch_inference_ranking_request_time_seconds")
+    .help("Total ranking query time in seconds")
+    .labelNames("model")
+    .register(registry)
 }

--- a/src/main/scala/ai/nixiesearch/core/nn/model/generative/GenerativeModelDict.scala
+++ b/src/main/scala/ai/nixiesearch/core/nn/model/generative/GenerativeModelDict.scala
@@ -5,6 +5,7 @@ import ai.nixiesearch.config.InferenceConfig.CompletionInferenceModelConfig.Llam
 import ai.nixiesearch.config.mapping.FieldName
 import ai.nixiesearch.core.Error.UserError
 import ai.nixiesearch.core.{Document, Logging}
+import ai.nixiesearch.core.metrics.Metrics
 import ai.nixiesearch.core.nn.{ModelHandle, ModelRef}
 import ai.nixiesearch.core.nn.ModelHandle.{HuggingFaceHandle, LocalModelHandle}
 import ai.nixiesearch.core.nn.huggingface.{HuggingFaceClient, ModelFileCache}
@@ -15,9 +16,11 @@ import cats.syntax.all.*
 import fs2.io.file.Path as Fs2Path
 import fs2.Stream
 
-case class GenerativeModelDict(models: Map[ModelRef, GenerativeModel]) {
+case class GenerativeModelDict(models: Map[ModelRef, GenerativeModel], metrics: Metrics) {
   def generate(name: ModelRef, input: String, maxTokens: Int): Stream[IO, String] = models.get(name) match {
-    case Some(model) => model.generate(input, maxTokens)
+    case Some(model) =>
+      Stream.eval(IO(metrics.inference.completionTotal.labelValues(name.name).inc())) >>
+        model.generate(input, maxTokens).evalTap(_ => IO(metrics.inference.completionGeneratedTokensTotal.labelValues(name.name).inc()))
     case None =>
       Stream.raiseError(
         UserError(s"RAG model handle ${name} cannot be found among these found in config: ${models.keys.toList}")
@@ -43,7 +46,8 @@ object GenerativeModelDict extends Logging {
 
   def create(
       models: Map[ModelRef, CompletionInferenceModelConfig],
-      cache: ModelFileCache
+      cache: ModelFileCache,
+      metrics: Metrics
   ): Resource[IO, GenerativeModelDict] =
     for {
       generativeModels <- models.toList.map {
@@ -53,7 +57,7 @@ object GenerativeModelDict extends Logging {
           createLocal(handle, name, conf).map(model => name -> model)
       }.sequence
     } yield {
-      GenerativeModelDict(generativeModels.toMap)
+      GenerativeModelDict(generativeModels.toMap, metrics)
     }
 
   def createHuggingface(

--- a/src/main/scala/ai/nixiesearch/index/Models.scala
+++ b/src/main/scala/ai/nixiesearch/index/Models.scala
@@ -1,6 +1,7 @@
 package ai.nixiesearch.index
 
 import ai.nixiesearch.config.{CacheConfig, InferenceConfig}
+import ai.nixiesearch.core.metrics.Metrics
 import ai.nixiesearch.core.nn.huggingface.ModelFileCache
 import ai.nixiesearch.core.nn.model.embedding.EmbedModelDict
 import ai.nixiesearch.core.nn.model.generative.GenerativeModelDict
@@ -15,12 +16,13 @@ case class Models(embedding: EmbedModelDict, generative: GenerativeModelDict, ra
 object Models {
   def create(
       inferenceConfig: InferenceConfig,
-      cacheConfig: CacheConfig
+      cacheConfig: CacheConfig,
+      metrics: Metrics
   ): Resource[IO, Models] = for {
     cache      <- Resource.eval(ModelFileCache.create(Paths.get(cacheConfig.dir)))
-    embeddings <- EmbedModelDict.create(inferenceConfig.embedding, cache)
-    generative <- GenerativeModelDict.create(inferenceConfig.completion, cache)
-    ranker     <- RankModelDict.create(inferenceConfig.ranker, cache)
+    embeddings <- EmbedModelDict.create(inferenceConfig.embedding, cache, metrics)
+    generative <- GenerativeModelDict.create(inferenceConfig.completion, cache, metrics)
+    ranker     <- RankModelDict.create(inferenceConfig.ranker, cache, metrics)
   } yield {
     Models(embeddings, generative, ranker)
   }

--- a/src/main/scala/ai/nixiesearch/main/subcommands/IndexMode.scala
+++ b/src/main/scala/ai/nixiesearch/main/subcommands/IndexMode.scala
@@ -46,7 +46,7 @@ object IndexMode extends Logging {
       )
       _       <- Resource.eval(debug(s"found index mapping for index '${indexMapping.name}'"))
       metrics <- Resource.pure(Metrics())
-      models  <- Models.create(inference, cacheConfig)
+      models  <- Models.create(inference, cacheConfig, metrics)
       index   <- Index.forIndexing(indexMapping, models)
       indexer <- Indexer.open(index, metrics)
     } yield {
@@ -73,8 +73,8 @@ object IndexMode extends Logging {
   def runApi(indexes: List[IndexMapping], source: ApiIndexSourceArgs, config: Config): IO[Unit] = {
     val server = for {
       _       <- Resource.eval(info("Starting in 'index' mode with only indexer available as a REST API"))
-      models  <- Models.create(config.inference, config.core.cache)
       metrics <- Resource.pure(Metrics())
+      models  <- Models.create(config.inference, config.core.cache, metrics)
       indexers <- indexes
         .map(im =>
           for {

--- a/src/main/scala/ai/nixiesearch/main/subcommands/SearchMode.scala
+++ b/src/main/scala/ai/nixiesearch/main/subcommands/SearchMode.scala
@@ -25,8 +25,8 @@ object SearchMode extends Logging {
 
   def api(args: SearchArgs, config: Config): Resource[IO, Server] = for {
     _       <- Resource.eval(info("Starting in 'search' mode with only searcher"))
-    models  <- Models.create(config.inference, config.core.cache)
     metrics <- Resource.pure(Metrics())
+    models  <- Models.create(config.inference, config.core.cache, metrics)
     searchers <- config.schema.values.toList
       .map(im =>
         for {

--- a/src/main/scala/ai/nixiesearch/main/subcommands/SearchMode.scala
+++ b/src/main/scala/ai/nixiesearch/main/subcommands/SearchMode.scala
@@ -53,7 +53,7 @@ object SearchMode extends Logging {
       List(AdminRoute(config).routes),
       List(MainRoute().routes),
       List(TypicalErrorsRoute(searchers.map(_.index.name.value)).routes),
-      List(InferenceRoute(models, metrics).routes),
+      List(InferenceRoute(models).routes),
       List(MetricsRoute(metrics).routes)
     ).flatten.reduce(_ <+> _)
     api <- API.start(routes, config.core.host, config.core.port)

--- a/src/main/scala/ai/nixiesearch/main/subcommands/StandaloneMode.scala
+++ b/src/main/scala/ai/nixiesearch/main/subcommands/StandaloneMode.scala
@@ -39,7 +39,7 @@ object StandaloneMode extends Logging {
       List(AdminRoute(config).routes),
       List(MainRoute().routes),
       List(HealthRoute().routes),
-      List(InferenceRoute(models, metrics).routes),
+      List(InferenceRoute(models).routes),
       List(MetricsRoute(metrics).routes)
     ).flatten.reduce(_ <+> _)
     server <- API.start(routes, config.core.host, config.core.port)

--- a/src/main/scala/ai/nixiesearch/main/subcommands/StandaloneMode.scala
+++ b/src/main/scala/ai/nixiesearch/main/subcommands/StandaloneMode.scala
@@ -22,11 +22,11 @@ object StandaloneMode extends Logging {
 
   def api(args: StandaloneArgs, config: Config): Resource[IO, Server] = for {
     _ <- Resource.eval(info("Starting in 'standalone' mode with indexer+searcher colocated within a single process"))
-    models <- Models.create(config.inference, config.core.cache)
+    metrics <- Resource.pure(Metrics())
+    models <- Models.create(config.inference, config.core.cache, metrics)
     indexes <- config.schema.values.toList
       .map(im => Index.local(im, models))
       .sequence
-    metrics <- Resource.pure(Metrics())
     indexers <- indexes
       .map(index => Indexer.open(index, metrics).flatTap(indexer => PeriodicFlushStream.run(index, indexer)))
       .sequence

--- a/src/test/scala/ai/nixiesearch/api/InferenceRouteTest.scala
+++ b/src/test/scala/ai/nixiesearch/api/InferenceRouteTest.scala
@@ -17,7 +17,7 @@ class InferenceRouteTest extends AnyFlatSpec with Matchers with SearchTest {
     {
       val response =
         send[EmbeddingInferenceRequest, EmbeddingInferenceResponse](
-          InferenceRoute(index.indexer.index.models, Metrics()).routes,
+          InferenceRoute(index.indexer.index.models).routes,
           "http://localhost/inference/embedding/text",
           Some(EmbeddingInferenceRequest(List(EmbeddingDocument("hello world")))),
           Method.POST
@@ -30,7 +30,7 @@ class InferenceRouteTest extends AnyFlatSpec with Matchers with SearchTest {
     {
       val response =
         send[CompletionRequest, CompletionResponse](
-          InferenceRoute(index.indexer.index.models, Metrics()).routes,
+          InferenceRoute(index.indexer.index.models).routes,
           "http://localhost/inference/completion/qwen2",
           Some(CompletionRequest(prompt = "why did chicken cross the road? answer short.", max_tokens = 10)),
           Method.POST
@@ -43,7 +43,7 @@ class InferenceRouteTest extends AnyFlatSpec with Matchers with SearchTest {
     {
       val response =
         send[CompletionRequest, String](
-          InferenceRoute(index.indexer.index.models, Metrics()).routes,
+          InferenceRoute(index.indexer.index.models).routes,
           "http://localhost/inference/completion/qwen2",
           Some(
             CompletionRequest(prompt = "why did chicken cross the road? answer short.", max_tokens = 10, stream = true)

--- a/src/test/scala/ai/nixiesearch/core/nn/model/generative/LlamacppGenerativeModelTest.scala
+++ b/src/test/scala/ai/nixiesearch/core/nn/model/generative/LlamacppGenerativeModelTest.scala
@@ -1,6 +1,7 @@
 package ai.nixiesearch.core.nn.model.generative
 
 import ai.nixiesearch.config.InferenceConfig
+import ai.nixiesearch.core.metrics.Metrics
 import ai.nixiesearch.core.nn.ModelHandle.HuggingFaceHandle
 import ai.nixiesearch.core.nn.ModelRef
 import ai.nixiesearch.core.nn.huggingface.ModelFileCache
@@ -19,7 +20,7 @@ class LlamacppGenerativeModelTest extends AnyFlatSpec with Matchers {
   it should "load, generate text, unload" in {
     val (cache, shutdownHandle) =
       GenerativeModelDict
-        .create(TestInferenceConfig.full().completion, fileCache)
+        .create(TestInferenceConfig.full().completion, fileCache, Metrics())
         .allocated
         .unsafeRunSync()
 

--- a/src/test/scala/ai/nixiesearch/e2e/RemoteIndexSearchEndToEndTest.scala
+++ b/src/test/scala/ai/nixiesearch/e2e/RemoteIndexSearchEndToEndTest.scala
@@ -24,7 +24,7 @@ class RemoteIndexSearchEndToEndTest extends AnyFlatSpec with Matchers {
   lazy val mapping = conf.schema(IndexName.unsafe("movies"))
 
   it should "write index to s3" taggedAs (EndToEnd.Index) in {
-    val (models, modelsShutdown)   = Models.create(conf.inference, CacheConfig()).allocated.unsafeRunSync()
+    val (models, modelsShutdown)   = Models.create(conf.inference, CacheConfig(), Metrics()).allocated.unsafeRunSync()
     val (master, masterShutdown)   = Index.forIndexing(mapping, models).allocated.unsafeRunSync()
     val (indexer, indexerShutdown) = Indexer.open(master, Metrics()).allocated.unsafeRunSync()
     val docs = DatasetLoader.fromFile(s"$pwd/src/test/resources/datasets/movies/movies.jsonl.gz", mapping)
@@ -37,7 +37,7 @@ class RemoteIndexSearchEndToEndTest extends AnyFlatSpec with Matchers {
   }
 
   it should "search from s3" taggedAs (EndToEnd.Index) in {
-    val (models, modelsShutdown)     = Models.create(conf.inference, CacheConfig()).allocated.unsafeRunSync()
+    val (models, modelsShutdown)     = Models.create(conf.inference, CacheConfig(), Metrics()).allocated.unsafeRunSync()
     val (slave, slaveShutdown)       = Index.forSearch(mapping, models).allocated.unsafeRunSync()
     val (searcher, searcherShutdown) = Searcher.open(slave, Metrics()).allocated.unsafeRunSync()
     val response                     = searcher.search(SearchRequest(query = MatchAllQuery())).unsafeRunSync()

--- a/src/test/scala/ai/nixiesearch/index/compat/CompatUtil.scala
+++ b/src/test/scala/ai/nixiesearch/index/compat/CompatUtil.scala
@@ -47,9 +47,9 @@ object CompatUtil {
   }
 
   def writeResource(path: String): Resource[IO, Searcher] = for {
-    models   <- Models.create(inference, CacheConfig())
-    index    <- LocalIndex.create(mapping, LocalStoreConfig(DiskLocation(Paths.get(path))), models)
     metrics  <- Resource.pure(Metrics())
+    models   <- Models.create(inference, CacheConfig(), metrics)
+    index    <- LocalIndex.create(mapping, LocalStoreConfig(DiskLocation(Paths.get(path))), models)
     indexer  <- Indexer.open(index, metrics)
     searcher <- Searcher.open(index, metrics)
     _        <- Resource.eval(indexer.addDocuments(docs))
@@ -61,7 +61,7 @@ object CompatUtil {
   }
 
   def readResource(path: String): Resource[IO, Searcher] = for {
-    models   <- Models.create(inference, CacheConfig())
+    models   <- Models.create(inference, CacheConfig(), Metrics())
     index    <- LocalIndex.create(mapping, LocalStoreConfig(DiskLocation(Paths.get(path))), models)
     searcher <- Searcher.open(index, Metrics())
   } yield {

--- a/src/test/scala/ai/nixiesearch/index/sync/local/LocalIndexSuite.scala
+++ b/src/test/scala/ai/nixiesearch/index/sync/local/LocalIndexSuite.scala
@@ -16,7 +16,7 @@ trait LocalIndexSuite extends AnyFlatSpec with Matchers {
   def config: LocalStoreConfig
 
   it should "start with empty index" in {
-    val (models, modelsShutdown) = Models.create(TestInferenceConfig(), CacheConfig()).allocated.unsafeRunSync()
+    val (models, modelsShutdown) = Models.create(TestInferenceConfig(), CacheConfig(), Metrics()).allocated.unsafeRunSync()
     val (localIndex, localShutdown) = LocalIndex
       .create(TestIndexMapping(), config, models)
       .allocated
@@ -33,7 +33,7 @@ trait LocalIndexSuite extends AnyFlatSpec with Matchers {
   }
 
   it should "write docs and search over them" in {
-    val (models, modelsShutdown) = Models.create(TestInferenceConfig(), CacheConfig()).allocated.unsafeRunSync()
+    val (models, modelsShutdown) = Models.create(TestInferenceConfig(), CacheConfig(), Metrics()).allocated.unsafeRunSync()
     val (localIndex, localShutdown) = LocalIndex
       .create(TestIndexMapping(), config, models)
       .allocated

--- a/src/test/scala/ai/nixiesearch/index/sync/master/MasterSlaveIndexTest.scala
+++ b/src/test/scala/ai/nixiesearch/index/sync/master/MasterSlaveIndexTest.scala
@@ -25,7 +25,8 @@ class MasterSlaveIndexTest extends AnyFlatSpec with Matchers {
   )
 
   it should "start from empty" ignore {
-    val (models, modelsShutdown) = Models.create(TestInferenceConfig(), CacheConfig()).allocated.unsafeRunSync()
+    val (models, modelsShutdown) =
+      Models.create(TestInferenceConfig(), CacheConfig(), Metrics()).allocated.unsafeRunSync()
     val (emptyIndex, indexClose) =
       MasterIndex.create(TestIndexMapping(), config(), models).allocated.unsafeRunSync()
     emptyIndex.sync().unsafeRunSync()
@@ -36,7 +37,8 @@ class MasterSlaveIndexTest extends AnyFlatSpec with Matchers {
   }
 
   it should "start, write, stop" in {
-    val (models, modelsShutdown) = Models.create(TestInferenceConfig(), CacheConfig()).allocated.unsafeRunSync()
+    val (models, modelsShutdown) =
+      Models.create(TestInferenceConfig(), CacheConfig(), Metrics()).allocated.unsafeRunSync()
     val (masterIndex, masterClose) =
       MasterIndex.create(TestIndexMapping(), config(), models).allocated.unsafeRunSync()
     val (writer, writerClose) = Indexer.open(masterIndex, Metrics()).allocated.unsafeRunSync()
@@ -49,8 +51,9 @@ class MasterSlaveIndexTest extends AnyFlatSpec with Matchers {
   }
 
   it should "start, write, search, stop" in {
-    val (models, modelsShutdown) = Models.create(TestInferenceConfig(), CacheConfig()).allocated.unsafeRunSync()
-    val conf                     = config()
+    val (models, modelsShutdown) =
+      Models.create(TestInferenceConfig(), CacheConfig(), Metrics()).allocated.unsafeRunSync()
+    val conf = config()
     val (masterIndex, masterClose) =
       MasterIndex.create(TestIndexMapping(), conf, models).allocated.unsafeRunSync()
     val (writer, writerClose) = Indexer.open(masterIndex, Metrics()).allocated.unsafeRunSync()
@@ -71,8 +74,9 @@ class MasterSlaveIndexTest extends AnyFlatSpec with Matchers {
   }
 
   it should "start, write, stop, search" in {
-    val (models, modelsShutdown) = Models.create(TestInferenceConfig(), CacheConfig()).allocated.unsafeRunSync()
-    val conf                     = config()
+    val (models, modelsShutdown) =
+      Models.create(TestInferenceConfig(), CacheConfig(), Metrics()).allocated.unsafeRunSync()
+    val conf = config()
     val (masterIndex, masterClose) =
       MasterIndex.create(TestIndexMapping(), conf, models).allocated.unsafeRunSync()
     val (writer, writerClose) = Indexer.open(masterIndex, Metrics()).allocated.unsafeRunSync()

--- a/src/test/scala/ai/nixiesearch/util/LocalNixie.scala
+++ b/src/test/scala/ai/nixiesearch/util/LocalNixie.scala
@@ -51,9 +51,9 @@ case class LocalNixie(searcher: Searcher, indexer: Indexer) {
 
 object LocalNixie {
   def create(mapping: IndexMapping, inference: InferenceConfig): Resource[IO, LocalNixie] = for {
-    models   <- Models.create(inference, CacheConfig())
-    index    <- LocalIndex.create(mapping, LocalStoreConfig(MemoryLocation()), models)
     metrics  <- Resource.pure(Metrics())
+    models   <- Models.create(inference, CacheConfig(), metrics)
+    index    <- LocalIndex.create(mapping, LocalStoreConfig(MemoryLocation()), models)
     indexer  <- Indexer.open(index, metrics)
     searcher <- Searcher.open(index, metrics)
   } yield {


### PR DESCRIPTION
So we can also count metrics when doing inference on search/indexing/rag.