### PR TITLE
add required field support

### DIFF
--- a/docs/docs/features/indexing/mapping.md
+++ b/docs/docs/features/indexing/mapping.md
@@ -56,6 +56,7 @@ schema:
         sort: false   # optional, default false
         facet: false  # optional, default false
         filter: false # optional, default false 
+        required: false # optional, default false
 ```
 
 So by default all fields in Nixiesearch are:
@@ -64,6 +65,7 @@ So by default all fields in Nixiesearch are:
 * `sort: false`: you can't sort over field without explicitly marking a field as sortable. 
 * `facet: false`: you can't perform facet aggregations by default.
 * `filter: false`: you cannot filter over fields by default.
+* `required: false`: fields are optional by default, matching Elasticsearch behavior. Set to `true` to enforce a specific document schema and reject documents with missing fields.
 
 !!! warning
 
@@ -110,7 +112,7 @@ The [`multi_match`](../search/query/retrieve/multi_match.md) search operator als
 
 ## Text field mapping
 
-Apart from common `type`, `store`, `filter`, `sort` and `facet` parameters, text fields have a set of other search-related options:
+Apart from common `type`, `store`, `filter`, `sort`, `facet` and `required` parameters, text fields have a set of other search-related options:
 
 * A field can be `search`able, with [lexical](#lexical-search), [semantic](#semantic-search) and [hybrid retrieval](#hybrid-search).
 * You can use field contents to generate search [autocomplete suggestions](../autocomplete/index.md)

--- a/src/main/scala/ai/nixiesearch/config/mapping/FieldSchema.scala
+++ b/src/main/scala/ai/nixiesearch/config/mapping/FieldSchema.scala
@@ -23,7 +23,7 @@ sealed trait FieldSchema[T <: Field] {
   def sort: Boolean
   def facet: Boolean
   def filter: Boolean
-
+  def required: Boolean
 }
 
 object FieldSchema {
@@ -54,7 +54,8 @@ object FieldSchema {
       sort: Boolean = false,
       facet: Boolean = false,
       filter: Boolean = false,
-      suggest: Option[SuggestSchema] = None
+      suggest: Option[SuggestSchema] = None,
+      required: Boolean = false
   ) extends TextLikeFieldSchema[TextField]
       with FieldSchema[TextField]
 
@@ -65,7 +66,8 @@ object FieldSchema {
       sort: Boolean = false,
       facet: Boolean = false,
       filter: Boolean = false,
-      suggest: Option[SuggestSchema] = None
+      suggest: Option[SuggestSchema] = None,
+      required: Boolean = false
   ) extends TextLikeFieldSchema[TextListField]
       with FieldSchema[TextListField]
 
@@ -74,7 +76,8 @@ object FieldSchema {
       store: Boolean = true,
       sort: Boolean = false,
       facet: Boolean = false,
-      filter: Boolean = false
+      filter: Boolean = false,
+      required: Boolean = false
   ) extends FieldSchema[IntField]
 
   case class LongFieldSchema(
@@ -82,7 +85,8 @@ object FieldSchema {
       store: Boolean = true,
       sort: Boolean = false,
       facet: Boolean = false,
-      filter: Boolean = false
+      filter: Boolean = false,
+      required: Boolean = false
   ) extends FieldSchema[LongField]
 
   case class FloatFieldSchema(
@@ -90,7 +94,8 @@ object FieldSchema {
       store: Boolean = true,
       sort: Boolean = false,
       facet: Boolean = false,
-      filter: Boolean = false
+      filter: Boolean = false,
+      required: Boolean = false
   ) extends FieldSchema[FloatField]
 
   case class DoubleFieldSchema(
@@ -98,7 +103,8 @@ object FieldSchema {
       store: Boolean = true,
       sort: Boolean = false,
       facet: Boolean = false,
-      filter: Boolean = false
+      filter: Boolean = false,
+      required: Boolean = false
   ) extends FieldSchema[DoubleField]
 
   case class BooleanFieldSchema(
@@ -106,14 +112,16 @@ object FieldSchema {
       store: Boolean = true,
       sort: Boolean = false,
       facet: Boolean = false,
-      filter: Boolean = false
+      filter: Boolean = false,
+      required: Boolean = false
   ) extends FieldSchema[BooleanField]
 
   case class GeopointFieldSchema(
       name: FieldName,
       store: Boolean = true,
       sort: Boolean = false,
-      filter: Boolean = false
+      filter: Boolean = false,
+      required: Boolean = false
   ) extends FieldSchema[GeopointField] {
     def facet = false
   }
@@ -123,7 +131,8 @@ object FieldSchema {
       store: Boolean = true,
       sort: Boolean = false,
       facet: Boolean = false,
-      filter: Boolean = false
+      filter: Boolean = false,
+      required: Boolean = false
   ) extends FieldSchema[DateField] {
     def asInt = IntFieldSchema(name, store, sort, facet, filter)
   }
@@ -133,7 +142,8 @@ object FieldSchema {
       store: Boolean = true,
       sort: Boolean = false,
       facet: Boolean = false,
-      filter: Boolean = false
+      filter: Boolean = false,
+      required: Boolean = false
   ) extends FieldSchema[DateTimeField] {
     def asLong = LongFieldSchema(name, store, sort, facet, filter)
   }
@@ -157,6 +167,7 @@ object FieldSchema {
             case Some(false) => Right(None)
             case None        => Right(None)
           })
+        required <- c.downField("required").as[Option[Boolean]].map(_.getOrElse(false))
       } yield {
         TextFieldSchema(
           name = name,
@@ -165,7 +176,8 @@ object FieldSchema {
           sort = sort,
           facet = facet,
           filter = filter,
-          suggest = suggest
+          suggest = suggest,
+          required = required
         )
       }
     )
@@ -185,6 +197,7 @@ object FieldSchema {
             case Some(false) => Right(None)
             case None        => Right(None)
           })
+        required <- c.downField("required").as[Option[Boolean]].map(_.getOrElse(false))
       } yield {
         TextListFieldSchema(
           name = name,
@@ -193,92 +206,101 @@ object FieldSchema {
           sort = sort,
           facet = facet,
           filter = filter,
-          suggest = suggest
+          suggest = suggest,
+          required = required
         )
       }
     )
     def intFieldSchemaDecoder(name: FieldName): Decoder[IntFieldSchema] = Decoder.instance(c =>
       for {
-        store  <- c.downField("store").as[Option[Boolean]].map(_.getOrElse(true))
-        sort   <- c.downField("sort").as[Option[Boolean]].map(_.getOrElse(false))
-        facet  <- c.downField("facet").as[Option[Boolean]].map(_.getOrElse(false))
-        filter <- c.downField("filter").as[Option[Boolean]].map(_.getOrElse(false))
+        store    <- c.downField("store").as[Option[Boolean]].map(_.getOrElse(true))
+        sort     <- c.downField("sort").as[Option[Boolean]].map(_.getOrElse(false))
+        facet    <- c.downField("facet").as[Option[Boolean]].map(_.getOrElse(false))
+        filter   <- c.downField("filter").as[Option[Boolean]].map(_.getOrElse(false))
+        required <- c.downField("required").as[Option[Boolean]].map(_.getOrElse(false))
       } yield {
-        IntFieldSchema(name, store, sort, facet, filter)
+        IntFieldSchema(name, store, sort, facet, filter, required)
       }
     )
 
     def longFieldSchemaDecoder(name: FieldName): Decoder[LongFieldSchema] = Decoder.instance(c =>
       for {
-        store  <- c.downField("store").as[Option[Boolean]].map(_.getOrElse(true))
-        sort   <- c.downField("sort").as[Option[Boolean]].map(_.getOrElse(false))
-        facet  <- c.downField("facet").as[Option[Boolean]].map(_.getOrElse(false))
-        filter <- c.downField("filter").as[Option[Boolean]].map(_.getOrElse(false))
+        store    <- c.downField("store").as[Option[Boolean]].map(_.getOrElse(true))
+        sort     <- c.downField("sort").as[Option[Boolean]].map(_.getOrElse(false))
+        facet    <- c.downField("facet").as[Option[Boolean]].map(_.getOrElse(false))
+        filter   <- c.downField("filter").as[Option[Boolean]].map(_.getOrElse(false))
+        required <- c.downField("required").as[Option[Boolean]].map(_.getOrElse(false))
       } yield {
-        LongFieldSchema(name, store, sort, facet, filter)
+        LongFieldSchema(name, store, sort, facet, filter, required)
       }
     )
 
     def floatFieldSchemaDecoder(name: FieldName): Decoder[FloatFieldSchema] = Decoder.instance(c =>
       for {
-        store  <- c.downField("store").as[Option[Boolean]].map(_.getOrElse(true))
-        sort   <- c.downField("sort").as[Option[Boolean]].map(_.getOrElse(false))
-        facet  <- c.downField("facet").as[Option[Boolean]].map(_.getOrElse(false))
-        filter <- c.downField("filter").as[Option[Boolean]].map(_.getOrElse(false))
+        store    <- c.downField("store").as[Option[Boolean]].map(_.getOrElse(true))
+        sort     <- c.downField("sort").as[Option[Boolean]].map(_.getOrElse(false))
+        facet    <- c.downField("facet").as[Option[Boolean]].map(_.getOrElse(false))
+        filter   <- c.downField("filter").as[Option[Boolean]].map(_.getOrElse(false))
+        required <- c.downField("required").as[Option[Boolean]].map(_.getOrElse(false))
       } yield {
-        FloatFieldSchema(name, store, sort, facet, filter)
+        FloatFieldSchema(name, store, sort, facet, filter, required)
       }
     )
 
     def doubleFieldSchemaDecoder(name: FieldName): Decoder[DoubleFieldSchema] = Decoder.instance(c =>
       for {
-        store  <- c.downField("store").as[Option[Boolean]].map(_.getOrElse(true))
-        sort   <- c.downField("sort").as[Option[Boolean]].map(_.getOrElse(false))
-        facet  <- c.downField("facet").as[Option[Boolean]].map(_.getOrElse(false))
-        filter <- c.downField("filter").as[Option[Boolean]].map(_.getOrElse(false))
+        store    <- c.downField("store").as[Option[Boolean]].map(_.getOrElse(true))
+        sort     <- c.downField("sort").as[Option[Boolean]].map(_.getOrElse(false))
+        facet    <- c.downField("facet").as[Option[Boolean]].map(_.getOrElse(false))
+        filter   <- c.downField("filter").as[Option[Boolean]].map(_.getOrElse(false))
+        required <- c.downField("required").as[Option[Boolean]].map(_.getOrElse(false))
       } yield {
-        DoubleFieldSchema(name, store, sort, facet, filter)
+        DoubleFieldSchema(name, store, sort, facet, filter, required)
       }
     )
 
     def booleanFieldSchemaDecoder(name: FieldName): Decoder[BooleanFieldSchema] = Decoder.instance(c =>
       for {
-        store  <- c.downField("store").as[Option[Boolean]].map(_.getOrElse(true))
-        sort   <- c.downField("sort").as[Option[Boolean]].map(_.getOrElse(false))
-        facet  <- c.downField("facet").as[Option[Boolean]].map(_.getOrElse(false))
-        filter <- c.downField("filter").as[Option[Boolean]].map(_.getOrElse(false))
+        store    <- c.downField("store").as[Option[Boolean]].map(_.getOrElse(true))
+        sort     <- c.downField("sort").as[Option[Boolean]].map(_.getOrElse(false))
+        facet    <- c.downField("facet").as[Option[Boolean]].map(_.getOrElse(false))
+        filter   <- c.downField("filter").as[Option[Boolean]].map(_.getOrElse(false))
+        required <- c.downField("required").as[Option[Boolean]].map(_.getOrElse(false))
       } yield {
-        BooleanFieldSchema(name, store, sort, facet, filter)
+        BooleanFieldSchema(name, store, sort, facet, filter, required)
       }
     )
     def dateFieldSchemaDecoder(name: FieldName): Decoder[DateFieldSchema] = Decoder.instance(c =>
       for {
-        store  <- c.downField("store").as[Option[Boolean]].map(_.getOrElse(true))
-        sort   <- c.downField("sort").as[Option[Boolean]].map(_.getOrElse(false))
-        facet  <- c.downField("facet").as[Option[Boolean]].map(_.getOrElse(false))
-        filter <- c.downField("filter").as[Option[Boolean]].map(_.getOrElse(false))
+        store    <- c.downField("store").as[Option[Boolean]].map(_.getOrElse(true))
+        sort     <- c.downField("sort").as[Option[Boolean]].map(_.getOrElse(false))
+        facet    <- c.downField("facet").as[Option[Boolean]].map(_.getOrElse(false))
+        filter   <- c.downField("filter").as[Option[Boolean]].map(_.getOrElse(false))
+        required <- c.downField("required").as[Option[Boolean]].map(_.getOrElse(false))
       } yield {
-        DateFieldSchema(name, store, sort, facet, filter)
+        DateFieldSchema(name, store, sort, facet, filter, required)
       }
     )
     def dateTimeFieldSchemaDecoder(name: FieldName): Decoder[DateTimeFieldSchema] = Decoder.instance(c =>
       for {
-        store  <- c.downField("store").as[Option[Boolean]].map(_.getOrElse(true))
-        sort   <- c.downField("sort").as[Option[Boolean]].map(_.getOrElse(false))
-        facet  <- c.downField("facet").as[Option[Boolean]].map(_.getOrElse(false))
-        filter <- c.downField("filter").as[Option[Boolean]].map(_.getOrElse(false))
+        store    <- c.downField("store").as[Option[Boolean]].map(_.getOrElse(true))
+        sort     <- c.downField("sort").as[Option[Boolean]].map(_.getOrElse(false))
+        facet    <- c.downField("facet").as[Option[Boolean]].map(_.getOrElse(false))
+        filter   <- c.downField("filter").as[Option[Boolean]].map(_.getOrElse(false))
+        required <- c.downField("required").as[Option[Boolean]].map(_.getOrElse(false))
       } yield {
-        DateTimeFieldSchema(name, store, sort, facet, filter)
+        DateTimeFieldSchema(name, store, sort, facet, filter, required)
       }
     )
 
     def geopointFieldSchemaDecoder(name: FieldName): Decoder[GeopointFieldSchema] = Decoder.instance(c =>
       for {
-        store  <- c.downField("store").as[Option[Boolean]].map(_.getOrElse(true))
-        sort   <- c.downField("sort").as[Option[Boolean]].map(_.getOrElse(false))
-        filter <- c.downField("filter").as[Option[Boolean]].map(_.getOrElse(false))
+        store    <- c.downField("store").as[Option[Boolean]].map(_.getOrElse(true))
+        sort     <- c.downField("sort").as[Option[Boolean]].map(_.getOrElse(false))
+        filter   <- c.downField("filter").as[Option[Boolean]].map(_.getOrElse(false))
+        required <- c.downField("required").as[Option[Boolean]].map(_.getOrElse(false))
       } yield {
-        GeopointFieldSchema(name, store, sort, filter)
+        GeopointFieldSchema(name, store, sort, filter, required)
       }
     )
 

--- a/src/main/scala/ai/nixiesearch/config/mapping/IndexMapping.scala
+++ b/src/main/scala/ai/nixiesearch/config/mapping/IndexMapping.scala
@@ -29,7 +29,8 @@ case class IndexMapping(
     fields: Map[FieldName, FieldSchema[? <: Field]]
 ) extends Logging {
 
-  val analyzer = PerFieldAnalyzer(new KeywordAnalyzer(), this)
+  val analyzer                             = PerFieldAnalyzer(new KeywordAnalyzer(), this)
+  lazy val requiredFields: List[FieldName] = fields.filter(_._2.required).keys.toList
 
   def fieldSchema(name: String): Option[FieldSchema[? <: Field]] = {
     fields.collectFirst {

--- a/src/test/scala/ai/nixiesearch/core/DocumentJsonTest.scala
+++ b/src/test/scala/ai/nixiesearch/core/DocumentJsonTest.scala
@@ -424,4 +424,20 @@ class DocumentJsonTest extends AnyFlatSpec with Matchers {
     }
   }
 
+  it should "reject documents with missing required fields" in {
+    given decoder: Decoder[Document] =
+      Document.decoderFor(
+        TestIndexMapping(
+          "test",
+          List(
+            TextFieldSchema(StringName("_id")),
+            TextFieldSchema(StringName("title"), required = true),
+            IntFieldSchema(StringName("count"))
+          )
+        )
+      )
+    val json = """{"_id": "a", "count": 1}"""
+    decode[Document](json) shouldBe a[Left[?, ?]]
+  }
+
 }


### PR DESCRIPTION
fixes #482 

tests and docs are also Claude Code generated with the following prompts:

* FieldSchema.scala file defines a required: Boolean field to mark document fields as required when parsing. Document.scala has a JSON parser enforcing the doc schema (also for required fields). Add a  single test (for TextField) to the DocumentJsonTest.scala to validate that parser correctly rejects documents with missing fields when required=true.
* matching on exact exception message is not good
* update the mapping.md mentioning required field support. do not add new sections, just extend the ones mentioning another common field settings (like filter/facet) and add notes about required option.
* required: false is made as default to match the default Elasticsearch behavior, when all fields are optional. in Nixiesearch schema you have an option to enforce a specific document schema, so you won't  have missing fields in documents. add this to the text.