### PR TITLE
Fix the RRF query in the quickstart docs

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -85,15 +85,16 @@ schema:
         search: false
 ```
 
-!!! note 
+!!! note
 
     Each document field definition **must have a type**. Schemaless dynamic mapping is considered an anti-pattern, as the search engine must know beforehand which structure to use for the index. [int, float, long, double, text, text[], bool](features/indexing/types/overview.md) field types are currently supported.
 
-See a full [index mapping reference](features/indexing/mapping.md) for more details on defining indexes, and [ML inference](features/inference/overview.md) on configuring ML models inside Nixiesearch for CPU and [GPU](deployment/distributed/gpu.md). 
+See a full [index mapping reference](features/indexing/mapping.md) for more details on defining indexes, and [ML inference](features/inference/overview.md) on configuring ML models inside Nixiesearch for CPU and [GPU](deployment/distributed/gpu.md).
 
 ## Starting the service
 
 Nixiesearch is distributed as a Docker container, which can be run with the following command:
+
 ```shell
 docker run -itp 8080:8080 -v .:/data nixiesearch/nixiesearch:latest standalone -c /data/config.yml
 ```
@@ -115,7 +116,7 @@ Options breakdown:
 
 * `-i` and `-t`: interactive docker mode with allocated TTY. Useful when you want to be able to press Ctrl-C to stop the application.
 * `-p 8080:8080`: expose the port 8080.
-* `-v .:/data`: mount current dir (with a `config.yml` file!) as a `/data` inside the container 
+* `-v .:/data`: mount current dir (with a `config.yml` file!) as a `/data` inside the container
 * `standalone`: a Nixiesearch running mode, with colocated indexer and searcher processes.
 * `-c /data/config.yml`: use a config file with `movies` index mapping
 
@@ -145,7 +146,7 @@ As Nixiesearch is running a local embedding model inference inside, indexing lar
 
 ## Sending search requests
 
-Query DSL in Nixiesearch is inspired but not compatible with the JSON syntax used in [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html)/[OpenSearch](https://opensearch.org/docs/latest/query-dsl/index/) Query DSL. 
+Query DSL in Nixiesearch is inspired but not compatible with the JSON syntax used in [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html)/[OpenSearch](https://opensearch.org/docs/latest/query-dsl/index/) Query DSL.
 
 To perform a single-field lexical search over our newly-created `movies` index, run the following cURL command:
 
@@ -165,7 +166,7 @@ curl -XPOST http://localhost:8080/v1/index/movies/search \
 
 You will get the following response:
 
-```json    
+```json
 {
   "took": 1,
   "hits": [
@@ -200,17 +201,17 @@ Let's go deeper and perform hybrid search query, by mixing lexical (using [match
 ```shell
 curl -XPOST http://localhost:8080/v1/index/movies/search \
   -H "Content-Type: application/json" \
-  -d '{ 
+  -d '{
     "query": {
       "rrf": {
-        "queries": [
-          {"match": {"title": "batman"}},
-          {"semantic": {"title": "batman nolan"}}
+        "retrieve": [
+          { "match": { "title": "batman" } },
+          { "semantic": { "title": "batman nolan" } }
         ],
         "rank_window_size": 20
-      } 
-    }, 
-    "fields": ["title"], 
+      }
+    },
+    "fields": ["title"],
     "size": 5
   }'
 ```


### PR DESCRIPTION
I've been hearing a lot of great things about nixiesearch recently, and really enjoyed seeing @shuttie's talk IRL at Berlin Buzzwords a few days ago!

After the talk, I followed the quickstart instructions to set up a local nixiesearch instance. Everything worked perfectly, until I hit the hybrid query. Running the query as it's written in the docs, I got a `DecodingFailure at .query.rrf.retrieve: Missing required field`

It looks like the query in the docs is using an outdated (?) `queries` field, which should instead have been set to `retrieve`. After making the change, the guide works perfectly :)