### PR TITLE
forbid extra fields in search requests

### DIFF
--- a/docs/docs/features/search/query/overview.md
+++ b/docs/docs/features/search/query/overview.md
@@ -26,7 +26,7 @@ Search request format is similar to existing Lucene-based search engines:
     "color_counts": {"term": {"field": "color"}}
   },
   "filters": {
-    "include": {"term": {"field": "category", "value": "pants"}}
+    "include": {"term": {"category": "pants"}}
   }
 }
 ```

--- a/src/main/scala/ai/nixiesearch/util/JsonUtils.scala
+++ b/src/main/scala/ai/nixiesearch/util/JsonUtils.scala
@@ -1,0 +1,25 @@
+package ai.nixiesearch.util
+
+import io.circe.{Decoder, DecodingFailure, HCursor, Json}
+
+import scala.compiletime.{constValueTuple, constValue}
+import scala.deriving.Mirror
+
+object JsonUtils {
+
+  inline def forbidExtraFields[T](json: Json)(using m: Mirror.ProductOf[T]): Decoder.Result[Unit] = {
+    val labels = constValueTuple[m.MirroredElemLabels].toList
+    val name   = constValue[m.MirroredLabel]
+    print(labels)
+    json.asObject match {
+      case Some(value) =>
+        value.keys.find(jsonKey => !labels.contains(jsonKey)) match {
+          case Some(value) =>
+            Left(DecodingFailure(s"${name} expects only fields ${labels} but got field '${value}'", Nil))
+          case None => Right({})
+        }
+      case None => Right({})
+    }
+
+  }
+}

--- a/src/test/scala/ai/nixiesearch/api/query/KnnQueryFilterTest.scala
+++ b/src/test/scala/ai/nixiesearch/api/query/KnnQueryFilterTest.scala
@@ -1,0 +1,111 @@
+package ai.nixiesearch.api.query
+
+import ai.nixiesearch.api.filter.Filters
+import ai.nixiesearch.api.filter.Predicate.TermPredicate
+import ai.nixiesearch.api.query.retrieve.KnnQuery
+import ai.nixiesearch.config.FieldSchema.{IntListFieldSchema, TextFieldSchema}
+import ai.nixiesearch.config.InferenceConfig
+import ai.nixiesearch.config.mapping.FieldName.StringName
+import ai.nixiesearch.config.mapping.SearchParams
+import ai.nixiesearch.config.mapping.SearchParams.SemanticInferenceParams
+import ai.nixiesearch.core.Document
+import ai.nixiesearch.core.field.{IntListField, TextField}
+import ai.nixiesearch.core.nn.ModelRef
+import ai.nixiesearch.util.{SearchTest, TestIndexMapping, TestInferenceConfig}
+import org.scalatest.matchers.should.Matchers
+import ai.nixiesearch.core.nn.model.embedding.EmbedModel.TaskType.Query
+import cats.effect.unsafe.implicits.global
+
+import scala.util.Try
+
+class KnnQueryFilterTest extends SearchTest with Matchers {
+  override def inference: InferenceConfig = TestInferenceConfig.semantic()
+  val mapping                             = TestIndexMapping(
+    "test",
+    fields = List(
+      TextFieldSchema(name = StringName("_id"), filter = true),
+      TextFieldSchema(
+        name = StringName("title"),
+        search = SearchParams(semantic = Some(SemanticInferenceParams(model = ModelRef("text"))))
+      ),
+      TextFieldSchema(name = StringName("tag"), filter = true),
+      IntListFieldSchema(name = StringName("iltag"), filter = true)
+    )
+  )
+  val docs = List(
+    Document(
+      List(
+        TextField("_id", "1"),
+        TextField("title", "red dress"),
+        TextField("tag", "a"),
+        IntListField("iltag", List(1, 2))
+      )
+    ),
+    Document(
+      List(
+        TextField("_id", "2"),
+        TextField("title", "white dress"),
+        TextField("tag", "a"),
+        IntListField("iltag", List(2, 3))
+      )
+    ),
+    Document(
+      List(
+        TextField("_id", "3"),
+        TextField("title", "red pajama"),
+        TextField("tag", "b"),
+        IntListField("iltag", List(3, 4))
+      )
+    )
+  )
+  it should "select matching documents for a knn query with str filter" in withIndex { index =>
+    {
+      val queryEmbed =
+        index.indexer.index.models.embedding.encode(ModelRef("text"), Query, "lady in red").unsafeRunSync()
+      val docs = index.search(
+        query = KnnQuery("title", queryEmbed, Some(3)),
+        filters = Some(
+          Filters(
+            include = Some(TermPredicate("tag", "a"))
+          )
+        ),
+        n = 3
+      )
+      docs shouldBe List("1", "2")
+    }
+  }
+  it should "select matching documents for a knn query with int list filter" in withIndex { index =>
+    {
+      val queryEmbed =
+        index.indexer.index.models.embedding.encode(ModelRef("text"), Query, "lady in red").unsafeRunSync()
+      val docs = index.search(
+        query = KnnQuery("title", queryEmbed, Some(3)),
+        filters = Some(
+          Filters(
+            include = Some(TermPredicate("iltag", 3))
+          )
+        ),
+        n = 3
+      )
+      docs shouldBe List("3", "2")
+    }
+  }
+  it should "fail on filter field mismatch" in withIndex { index =>
+    {
+      val queryEmbed =
+        index.indexer.index.models.embedding.encode(ModelRef("text"), Query, "lady in red").unsafeRunSync()
+      val docs = Try(
+        index.search(
+          query = KnnQuery("title", queryEmbed, Some(3)),
+          filters = Some(
+            Filters(
+              include = Some(TermPredicate("tagssss", "a"))
+            )
+          ),
+          n = 3
+        )
+      )
+      docs.isFailure shouldBe true
+    }
+  }
+}

--- a/src/test/scala/ai/nixiesearch/api/query/json/KnnQueryJsonTest.scala
+++ b/src/test/scala/ai/nixiesearch/api/query/json/KnnQueryJsonTest.scala
@@ -1,5 +1,6 @@
 package ai.nixiesearch.api.query.json
 
+import ai.nixiesearch.api.SearchRoute.SearchRequest
 import ai.nixiesearch.api.query.retrieve.KnnQuery
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -14,5 +15,32 @@ class KnnQueryJsonTest extends AnyFlatSpec with Matchers {
     decoded should matchPattern {
       case Right(KnnQuery("foo", vector, _, _)) if util.Arrays.equals(vector, Array(1f, 2f, 3f)) =>
     }
+  }
+
+  it should "decode full search request with filter" in {
+    val str = """{
+                |  "query": {
+                |    "knn": {
+                |      "field": "text",
+                |      "query_vector": [
+                |        -0.10364249348640442,
+                |        0.0293938759714365,
+                |        -0.03270823881030083
+                |      ],
+                |      "num_candidates": 16,
+                |      "k": 16
+                |    }
+                |  },
+                |  "size": 16,
+                |  "filters": {
+                |    "include": {
+                |      "term": {
+                |        "tag": 90
+                |      }
+                |    }
+                |  }
+                |}""".stripMargin
+    val decoded = decode[SearchRequest](str)
+    decoded.isRight shouldBe true
   }
 }

--- a/src/test/scala/ai/nixiesearch/api/query/json/SearchRequestJsonTest.scala
+++ b/src/test/scala/ai/nixiesearch/api/query/json/SearchRequestJsonTest.scala
@@ -1,0 +1,60 @@
+package ai.nixiesearch.api.query.json
+
+import ai.nixiesearch.api.SearchRoute.SearchRequest
+import ai.nixiesearch.api.aggregation.Aggregation.TermAggregation
+import ai.nixiesearch.api.aggregation.Aggs
+import ai.nixiesearch.api.filter.Filters
+import ai.nixiesearch.api.filter.Predicate.TermPredicate
+import ai.nixiesearch.api.query.retrieve.MatchAllQuery
+import ai.nixiesearch.config.mapping.FieldName.StringName
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import io.circe.parser.*
+
+class SearchRequestJsonTest extends AnyFlatSpec with Matchers {
+  it should "decode valid query" in {
+    val str = """{
+                |  "query": {
+                |    "match_all": {}
+                |  },
+                |  "fields": ["title", "desc"],
+                |  "size": 20,
+                |  "aggs": {
+                |    "color_counts": {"term": {"field": "color"}}
+                |  },
+                |  "filters": {
+                |    "include": {"term": {"category": "pants"}}
+                |  }
+                |}
+                |""".stripMargin
+    val decoded = decode[SearchRequest](str)
+    decoded shouldBe Right(
+      SearchRequest(
+        query = MatchAllQuery(),
+        fields = List(StringName("title"), StringName("desc")),
+        size = 20,
+        aggs = Some(Aggs(Map("color_counts" -> TermAggregation("color")))),
+        filters = Some(Filters(include = Some(TermPredicate("category", "pants"))))
+      )
+    )
+  }
+  it should "decode complain on extra fields" in {
+    val str =
+      """{
+        |  "query": {
+        |    "match_all": {}
+        |  },
+        |  "fields": ["title", "desc"],
+        |  "size": 20,
+        |  "aggs": {
+        |    "color_counts": {"term": {"field": "color"}}
+        |  },
+        |  "filter": {
+        |    "include": {"term": {"category": "pants"}}
+        |  }
+        |}
+        |""".stripMargin
+    val decoded = decode[SearchRequest](str)
+    decoded shouldBe a[Left[?, ?]]
+  }
+}

--- a/src/test/scala/ai/nixiesearch/util/JsonUtilTest.scala
+++ b/src/test/scala/ai/nixiesearch/util/JsonUtilTest.scala
@@ -1,0 +1,26 @@
+package ai.nixiesearch.util
+
+import ai.nixiesearch.util.JsonUtilTest.DummyRequest
+import io.circe.Json
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class JsonUtilTest extends AnyFlatSpec with Matchers {
+  it should "pass matching keys" in {
+    val result =
+      JsonUtils.forbidExtraFields[DummyRequest](Json.obj("a" -> Json.fromInt(1), "b" -> Json.fromString("foo")))
+    result.isRight shouldBe true
+  }
+  it should "catch mismatches" in {
+    val result =
+      JsonUtils.forbidExtraFields[DummyRequest](
+        Json.obj("a" -> Json.fromInt(1), "b" -> Json.fromString("foo"), "c" -> Json.fromInt(2))
+      )
+    result.isRight shouldBe false
+  }
+
+}
+
+object JsonUtilTest {
+  case class DummyRequest(a: Int, b: String)
+}


### PR DESCRIPTION
As I mistyped `filter` instead of `filters` and my knn benchmark blew up.